### PR TITLE
Add composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "onepica/imagecdn",
+    "type": "magento-module",
+    "license":"OSL-3.0",
+    "description":"This extension enables you to host category and product images on a separate server with ease. This can improve page load time by offloading some of the stress from your web server and by allowing you to utilize a high performance content delivery network (CDN) or another remote host",
+    "authors":[
+        {
+            "name":"One Pica Codemaster",
+            "email":"codemaster@onepica.com"
+        }
+    ],
+    "require": {
+        "magento-hackathon/magento-composer-installer": "*"
+    }
+}

--- a/modman
+++ b/modman
@@ -1,0 +1,2 @@
+app/code/community/OnePica/ImageCdn					app/code/community/OnePica/ImageCdn
+app/etc/modules/OnePica_ImageCdn.xml					app/etc/modules/OnePica_ImageCdn.xml


### PR DESCRIPTION
Add a composer.json file and a modman file.

This makes imagecdn installable through [composer](https://getcomposer.org/)
It makes use of the [magento-composer-installer](https://github.com/magento-hackathon/magento-composer-installer) and [modman](https://github.com/colinmollenhour/modman)
